### PR TITLE
database: fix up length check of allocation strategy

### DIFF
--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -220,7 +220,7 @@ impl DatabaseConfiguration {
 
         for (dst, src) in strategy.iter_mut().zip(self.alloc_strategy.iter()) {
             assert!(
-                src.len() < NUM_STORAGE_CLASSES,
+                src.len() <= NUM_STORAGE_CLASSES,
                 "Invalid allocation strategy, can't try more than once per class"
             );
 


### PR DESCRIPTION
This PR fixes a check which was meant to exclude arrays of length `>` 4  from the database configuration, but `<` was used as the reverse operation which lead to errors on some fallback configurations.